### PR TITLE
Fix discovery server behavior 

### DIFF
--- a/java/de/fau/cooja/plugins/SerialPortDiscoveryServer.java
+++ b/java/de/fau/cooja/plugins/SerialPortDiscoveryServer.java
@@ -24,8 +24,8 @@ public class SerialPortDiscoveryServer extends Thread {
             return;
         }
 
-        try {
-            while(true) {
+        while(true) {
+            try {
                 Socket client = serverSocket.accept();
                 _logger.info("new Connection " + client + " established.");
 
@@ -41,9 +41,9 @@ public class SerialPortDiscoveryServer extends Thread {
 
                 client.shutdownOutput();
                 client.close();
+            } catch (IOException e) {
+                e.printStackTrace();
             }
-        } catch (IOException e) {
-            e.printStackTrace();
         }
 
     }


### PR DESCRIPTION
Fix discovery server behavior after there has been a problem with one connection (for example, premature close from client side).
